### PR TITLE
🍱 [Front] Personal - Module list

### DIFF
--- a/front/config/ci/.eslintrc.js
+++ b/front/config/ci/.eslintrc.js
@@ -13,12 +13,15 @@ module.exports = {
             ],
             rules: {
                 '@typescript-eslint/indent': ['error', 4],
+                '@typescript-eslint/member-delimiter-style': 'off',
                 '@typescript-eslint/no-extraneous-class': 'off',
                 '@typescript-eslint/semi': 'off',
                 '@typescript-eslint/space-before-function-paren': 'off',
                 'canonical/id-match': 'off',
                 'simple-import-sort/imports': 'off',
                 'prettier/prettier': 'off',
+                'typescript-sort-keys/interface': 'off',
+                'unicorn/numeric-separators-style': 'off',
             },
         },
         {

--- a/front/src/app/app.routes.ts
+++ b/front/src/app/app.routes.ts
@@ -1,12 +1,20 @@
 import { type Routes } from '@angular/router'
 import { PageNotFoundComponent } from './common/errors/page-not-found/page-not-found.component'
 import { HomeComponent } from './home/home.component'
+import {
+    ModuleListComponent as PersonalModuleListComponent,
+} from './personal/modules/module-list/module-list.component'
 
 export const routes: Routes = [
     {
         component: HomeComponent,
         path: '',
         title: 'Accueil',
+    },
+    {
+        component: PersonalModuleListComponent,
+        path: 'mon-espace/modules',
+        title: 'Mes modules',
     },
     {
         component: PageNotFoundComponent,

--- a/front/src/app/personal/modules/models/module-assessment.ts
+++ b/front/src/app/personal/modules/models/module-assessment.ts
@@ -1,0 +1,6 @@
+export type ModuleAssessment = {
+    id: number
+    label: string
+    date: Date
+    type: string
+}

--- a/front/src/app/personal/modules/models/module-card.ts
+++ b/front/src/app/personal/modules/models/module-card.ts
@@ -1,0 +1,11 @@
+import { type ModuleAssessment } from './module-assessment'
+import { type ModuleSession } from './module-session'
+
+export type ModuleCard = {
+    id: number
+    name: string
+    promotion: string
+    assessments: ModuleAssessment[]
+    sessions: ModuleSession[]
+    nextSession?: ModuleSession | null
+}

--- a/front/src/app/personal/modules/models/module-session.ts
+++ b/front/src/app/personal/modules/models/module-session.ts
@@ -1,0 +1,6 @@
+export type ModuleSession = {
+    label: string
+    name?: string | null
+    date: Date
+    type: string
+}

--- a/front/src/app/personal/modules/module-list/module-card/module-card.component.html
+++ b/front/src/app/personal/modules/module-list/module-card/module-card.component.html
@@ -1,0 +1,34 @@
+<mat-card>
+    <mat-card-header>
+        <div class="module-header">
+            <span class="module-name">{{ module.name }}</span>
+            <span class="module-promotion">{{ module.promotion }}</span>
+        </div>
+    </mat-card-header>
+    <div class="sub-header" *ngIf="module.nextSession">
+        Prochaine session le : {{ module.nextSession.label }}.
+    </div>
+
+    <mat-card-content>
+        <div>
+            <strong>Évaluations</strong>
+            <ng-template [ngIf]="module.assessments.length > 0" [ngIfElse]="elseNoAssessments">
+
+            </ng-template>
+            <ng-template #elseNoAssessments>
+                <div class="no-elements">Aucune évaluation programmée pour le module.</div>
+            </ng-template>
+        </div>
+
+        <div>
+            <strong>Séances</strong>
+            <ng-template [ngIf]="module.sessions.length > 0" [ngIfElse]="elseNoSessions">
+                <ng-template ngFor let-session [ngForOf]="module.sessions">
+                </ng-template>
+            </ng-template>
+            <ng-template #elseNoSessions>
+                <div class="no-elements">Aucune séance programmée pour le module.</div>
+            </ng-template>
+        </div>
+    </mat-card-content>
+</mat-card>

--- a/front/src/app/personal/modules/module-list/module-card/module-card.component.scss
+++ b/front/src/app/personal/modules/module-list/module-card/module-card.component.scss
@@ -1,0 +1,30 @@
+@import "styles";
+
+:host {
+  mat-card-header {
+    .module-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      width: 100%;
+
+      .module-name {
+        @extend %font-size-bigger;
+      }
+
+      .module-promotion {
+        color: $color-grey;
+        text-shadow: 0 0 1px $color-primary;
+      }
+    }
+  }
+
+  .sub-header {
+    @extend %font-size-smaller;
+    text-align: center;
+  }
+
+  mat-card-content {
+    margin-top: 1em;
+  }
+}

--- a/front/src/app/personal/modules/module-list/module-card/module-card.component.ts
+++ b/front/src/app/personal/modules/module-list/module-card/module-card.component.ts
@@ -1,0 +1,22 @@
+import { NgForOf, NgIf } from '@angular/common'
+import { Component, Input } from '@angular/core'
+import { MatCard, MatCardContent, MatCardHeader } from '@angular/material/card'
+import { type ModuleCard } from '../../models/module-card'
+
+@Component({
+    imports: [
+        MatCard,
+        MatCardHeader,
+        MatCardContent,
+        NgIf,
+        NgForOf,
+    ],
+    selector: 'app-personal-modules-list-card',
+    standalone: true,
+    styleUrl: './module-card.component.scss',
+    templateUrl: './module-card.component.html',
+})
+export class ModuleCardComponent {
+    @Input({ required: true })
+    public module!: ModuleCard
+}

--- a/front/src/app/personal/modules/module-list/module-list.component.html
+++ b/front/src/app/personal/modules/module-list/module-list.component.html
@@ -1,0 +1,21 @@
+<templates-main-page-heading [title]="'Mes modules'"></templates-main-page-heading>
+
+<section>
+    <mat-expansion-panel>
+        <mat-expansion-panel-header>
+            <mat-panel-title>
+                <mat-icon>filter_alt</mat-icon>
+                Filtres
+            </mat-panel-title>
+        </mat-expansion-panel-header>
+    </mat-expansion-panel>
+</section>
+
+<section id="module-list">
+    <ng-template ngFor let-module [ngForOf]="modules" [ngForTrackBy]="ngForModuleTrackBy">
+        <article>
+            <app-personal-modules-list-card [module]="module">
+            </app-personal-modules-list-card>
+        </article>
+    </ng-template>
+</section>

--- a/front/src/app/personal/modules/module-list/module-list.component.scss
+++ b/front/src/app/personal/modules/module-list/module-list.component.scss
@@ -1,0 +1,18 @@
+@import "styles";
+
+:host {
+  > section {
+    margin: $spacing-base 0;
+  }
+}
+
+#module-list {
+  display: flex;
+    justify-content: center;
+    gap: $spacing-base * .5;
+    flex-wrap: wrap;
+
+  > article {
+    width: 600px;
+  }
+}

--- a/front/src/app/personal/modules/module-list/module-list.component.ts
+++ b/front/src/app/personal/modules/module-list/module-list.component.ts
@@ -1,0 +1,68 @@
+import { NgForOf } from '@angular/common'
+import { Component } from '@angular/core'
+import { MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } from '@angular/material/expansion'
+import { MatIcon } from '@angular/material/icon'
+import { PageHeadingComponent } from '../../../shared/templates/main/page-heading/page-heading.component'
+import { type ModuleCard } from '../models/module-card'
+import { ModuleCardComponent } from './module-card/module-card.component'
+
+@Component({
+    imports: [
+        PageHeadingComponent,
+        MatExpansionPanelTitle,
+        MatExpansionPanel,
+        MatIcon,
+        MatExpansionPanelHeader,
+        NgForOf,
+        ModuleCardComponent,
+    ],
+    selector: 'app-personal-modules-list',
+    standalone: true,
+    styleUrl: './module-list.component.scss',
+    templateUrl: './module-list.component.html',
+})
+export class ModuleListComponent {
+    /* eslint-disable canonical/sort-keys --- Same sort as type */
+    public modules: ModuleCard[] = [
+        {
+            id: 0,
+            name: 'Architecture application web, Git, qualité application',
+            promotion: '3OLEN',
+            assessments: [],
+            sessions: [],
+        },
+        {
+            id: 0,
+            name: 'Projet 31',
+            promotion: '3OLEN',
+            assessments: [],
+            sessions: [],
+            nextSession: {
+                label: 'Vendredi 9 février',
+                type: 'course',
+                date: new Date(2024, 1, 9),
+            },
+        },
+        {
+            id: 0,
+            name: 'Projet 32',
+            promotion: '3OLEN',
+            assessments: [],
+            sessions: [],
+            nextSession: null,
+        },
+        {
+            id: 0,
+            name: 'Framework Symfony',
+            promotion: '3OLEN',
+            assessments: [],
+            sessions: [],
+            nextSession: null,
+        },
+    ]
+    /* eslint-enable canonical/sort-keys */
+
+    public ngForModuleTrackBy(index: number, module: ModuleCard): number {
+        return module.id
+    }
+}

--- a/front/src/styles.scss
+++ b/front/src/styles.scss
@@ -39,9 +39,14 @@ $project-theme: mat.define-light-theme((
 @import "styles/placeholders";
 @import "styles/variables";
 
+@import "styles/common/alert";
 @import "styles/common/card";
 
 body {
   font-family: Roboto, "Helvetica Neue", sans-serif;
   margin: 0;
+}
+
+strong {
+  font-weight: 500;
 }

--- a/front/src/styles/_placeholders.scss
+++ b/front/src/styles/_placeholders.scss
@@ -7,6 +7,12 @@
 }
 // endregion # Background color
 
+// region    # Border
+%border-radius-small {
+  border-radius: 0.4rem;
+}
+// endregion # Border
+
 // region    # Font size
 %font-size-heading {
   font-size: 1.5em;

--- a/front/src/styles/_variables.scss
+++ b/front/src/styles/_variables.scss
@@ -10,6 +10,10 @@ $color-danger: #dc3545;
 $color-danger-bg: #f8d7da;
 $color-danger-dark: #58151c;
 
+$color-grey: #ced4da;
+$color-grey-dark: #212529;
+$color-grey-light: #f8f9fa;
+
 $color-background: mat.get-color-from-palette(mat.$blue-grey-palette, 50);
 $color-background-dark: mat.get-color-from-palette(mat.$blue-grey-palette, 800);
 /* endregion # Colors */

--- a/front/src/styles/common/alert.scss
+++ b/front/src/styles/common/alert.scss
@@ -1,0 +1,34 @@
+// region    -- Private placeholders
+%-alert {
+  --alert-background-color: $color-grey-light;
+  --alert-border-color: $color-grey-light;
+  --alert-color: $color-grey-dark;
+
+  @include border($color: var(--alert-border-color));
+  @extend %border-radius-small;
+  background-color: var(--alert-background-color);
+  color: var(--alert-color);
+  margin: $spacing-base * .25 0;
+  padding: $spacing-base * .5;
+}
+%-alert-fade {
+  --alert-background-color: #E2E3E5;
+  --alert-border-color: #C4C8CB;
+  --alert-color: #2B2F32;
+}
+// endregion -- Private placeholders
+
+.alert {
+  @extend %-alert;
+
+  &-fade {
+    @extend %-alert-fade;
+  }
+}
+
+// region    -- Predefined components
+.no-elements {
+  @extend %-alert, %-alert-fade, %font-size-smaller;
+  text-align: center;
+}
+// endregion -- Predefined components


### PR DESCRIPTION
🍱 Templating
=============

* Create listing page for personal modules
  - Create module card template

💄 Styling
==========

* ➕ [common] `alert`: like Bootstrap ones
* [global]: Lower `font-weight` value for `strong` because of the typography

🏘️ Types
========

* ➕ `module` / `session` / `assessment` for "module card"

👷 CI configuration
===================

* 🔥 [eslint] Unnecessary rules

🌌 Proof
=======

![image](https://github.com/3OLEN/grading/assets/1339642/e570fa13-e70c-43d8-b0c5-9e6add122ad9)
